### PR TITLE
Refactor cmd router (use gameRouter for everything)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@babel/core": "^7.25.2",
         "@babel/preset-env": "^7.25.4",
         "@babel/preset-typescript": "^7.24.7",
+        "@jest-mock/express": "^2.1.0",
         "@jest/types": "^29.6.3",
         "@types/cors": "^2.8.16",
         "@types/express": "^4.17.21",
@@ -2068,6 +2069,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jest-mock/express": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@jest-mock/express/-/express-2.1.0.tgz",
+      "integrity": "sha512-wwij1960SVxJL+v5Eqw3Akn3S5TLfCtHnFqs2K9Zto7RLU5I/7YhOsYDZQfNcnGyiBdisDz5iT21SRO1CVfvKA==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "^4.17.21"
       }
     },
     "node_modules/@jest/console": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.4",
     "@babel/preset-typescript": "^7.24.7",
+    "@jest-mock/express": "^2.1.0",
     "@jest/types": "^29.6.3",
     "@types/cors": "^2.8.16",
     "@types/express": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Server portion of game, where primary state of game will reside. ",
   "main": "server.js",
   "scripts": {
-    "test": "npx jest --config src/jest.config.ts --detectOpenHandles",
+    "test": "NODE_ENV=test npx jest --config src/jest.config.ts --detectOpenHandles",
     "build": "npx tsc",
     "start": "node dist/index.js",
     "dev": "NODE_ENV=local concurrently \"npx tsc --watch\" \"nodemon -q dist/server.js\"",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -41,7 +41,7 @@ fetch(apiUrl)
         countryElement.textContent = countryInfo;
         countryElement.classList.add('country-box')
         countryElement.classList.add('text')
-        let owner = data.players.find(player => player.id === country.ownerId);
+        let owner = data.players.find(player => player.id === country.ownerID);
         if (owner) {
           countryElement.style.backgroundColor = owner.color; // Use the owner's color
         }
@@ -132,7 +132,8 @@ fourPlayers.addEventListener("click", () => {
   playerCount = 4
 })
 
-startGameButton.addEventListener("click", () => {
+startGameButton.addEventListener("click", async () => {
+  console.log("Start Game button clicked!");
   let players = [];
   for (let i = 1; i <= playerCount; i++) {
     console.log(`player${i}Name and playerCount = ${playerCount}`);
@@ -141,17 +142,20 @@ startGameButton.addEventListener("click", () => {
       name: document.getElementById(`player${i}Name`).value,
       color: document.getElementById(`player${i}Color`).value
     });
+    console.log(`players = ${players}`);
+    if (i === playerCount) {
+      await startGameFlow(players)
+      modal.style.display = "none"
   }
-  console.log(`players = ${players}`);
-  startGameFlow(players);
-  modal.style.display = "none";
+  }
 })
+
 
 cancelButton.addEventListener("click", () => {
   modal.style.display = "none";
 })
 
-function startGameFlow(players)
+async function startGameFlow(players)
 {
 
     

--- a/src/commands/commandController.test.ts
+++ b/src/commands/commandController.test.ts
@@ -1,0 +1,48 @@
+import {describe, expect, it} from '@jest/globals';
+import CommandController from './commandController';
+import GameStateController from '../game/services/gameState';
+import db from '../db/db';
+import { Request, Response } from 'express';
+import { getMockReq, getMockRes } from '@jest-mock/express';
+
+
+
+describe('CommandController Integration Tests', () => {
+    it('Should deploy troops to a country', async () => {
+        
+        let players = [
+            {
+                id: 1,
+                name: "Justin",
+                armies: 0,
+                color: "Red"
+            },
+            {
+                id: 2,
+                name: "Joan",
+                armies: 0,
+                color: "Blue"
+            }
+        ];
+
+        const data = await GameStateController(db).initialize(players);
+        const fetchedGame = await GameStateController(db).get(data.id);
+        const req: Request = getMockReq(
+            {
+                params: {
+                    id: data.id
+                },
+                body: {
+                    targetCountry: 1,
+                    troopCount: 1
+                }
+            }
+        );
+        const {res, next} = getMockRes()
+        await CommandController().deployTroops(req, res);
+        const updatedGame = await GameStateController(db).get(data.id);
+        console.log(`Armies before: ${fetchedGame.country[0].armies} \nArmies after: ${updatedGame.country[0].armies} \nTroop Count: ${req.body.troopCount}`)
+        expect(fetchedGame.country[0].armies).toEqual(updatedGame.country[0].armies-req.body.troopCount);
+    });
+    
+})

--- a/src/commands/commandController.ts
+++ b/src/commands/commandController.ts
@@ -24,13 +24,13 @@ function CommandController() {
     }
 
     async function deployTroops(req: Request, res: Response) {
-        let currentState: GameStateRecord = await GameStateController(db).get(req.body.gameID); //TODO: rework to not read DB so often
+        let currentState: GameStateRecord = await GameStateController(db).get(req.params.id); //TODO: rework to not read DB so often
         const activePlayer: number = parseInt(currentState.activePlayerId);
         let targetCountry: number = req.body.targetCountry;
         currentState.country[targetCountry-1].armies += req.body.troopCount;
         currentState.players[activePlayer-1].armies -= req.body.troopCount;
         await GameStateController(db).update(currentState);
-        await GameStateController(db).updatePlayers(req.body.gameID, currentState.players);
+        await GameStateController(db).updatePlayers(req.params.id, currentState.players);
         res.send(currentState)
 
     }

--- a/src/commands/commandController.ts
+++ b/src/commands/commandController.ts
@@ -10,14 +10,15 @@ import turnStart from '../game/services/startTurn'
 import { NoTroopError, AttackError } from '../common/types/errors'
 import Knex from 'knex';
 import {default as knexConfig} from '../knexfile'
+import db from '../db/db';
 
 
 
-const db = Knex(knexConfig[process.env.NODE_ENV || 'development']); 
+// const db = Knex(knexConfig[process.env.NODE_ENV || 'development']); 
 
 function CommandController() {
     async function get(req: Request, res: Response) {
-        let currentState: GameStateRecord = await GameStateController(db).get(req.body.gameID);
+        let currentState: GameStateRecord = await GameStateController(db).get(req.params.id);
         const commands = availableCommands(currentState.phase, req.body.player, currentState.activePlayerId);
         //TODO validate the commands
         res.send(commands);
@@ -37,7 +38,7 @@ function CommandController() {
 
     async function attack(req: Request, res: Response) {
         //Read state and get the attacking country, defending country, and troop count
-        let currentState: GameStateRecord = await GameStateController(db).get(req.body.gameID);
+        let currentState: GameStateRecord = await GameStateController(db).get(req.params.id);
         const attackingCountryID: number = parseInt(req.body.attackingCountry);
         const defendingCountryID: number = parseInt(req.body.defendingCountry);
         const troopCount: number = req.body.troopCount;
@@ -98,7 +99,7 @@ function CommandController() {
     // }
 
     async function endTurn(req: Request, res: Response) {
-        let currentState: GameStateRecord = await GameStateController(db).get(req.body.gameID);
+        let currentState: GameStateRecord = await GameStateController(db).get(req.params.id);
         const activePlayer: number = parseInt(currentState.activePlayerId, 10);
         if (currentState.phase == 'deploy') {
             let armyCount:number = 0;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -36,7 +36,7 @@ export interface CountryRecord {
 
 export interface CountryOwnershipRecord {
     countryId: string;
-    ownerId: string;
+    ownerID: string;
 }
 
 export interface Continent {

--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -2,6 +2,10 @@ import Knex from "knex";
 import { default as knexConfig } from "../knexfile"
 
 // Initialize Knex instance for testing
-const db = Knex(knexConfig.test);
+const environment = process.env.NODE_ENV || "local";
+if (!knexConfig[environment]) {
+    throw new Error(`Unable to find knex config for environment: ${environment}`);
+}
+const db = Knex(knexConfig[environment]);
 
 export default db;

--- a/src/game/gameRouter.ts
+++ b/src/game/gameRouter.ts
@@ -2,10 +2,12 @@ import { Router } from 'express';
 import bodyParser from "body-parser";
 import { Engagement } from '../common/types'
 import game from './gameController';
+import CommandController from '../commands/commandController';
 
 
 const gameRouter = Router();
 const controller = game();
+const cmdController = CommandController();
 gameRouter.use(bodyParser.json())
 
 gameRouter.get('/', controller.list);
@@ -13,7 +15,10 @@ gameRouter.post('/new', controller.newGame);
 gameRouter.get('/:id', controller.get);
 gameRouter.get('/:id/countries', controller.getCountries);
 gameRouter.get('/:id/players', controller.getPlayers);
-// router.post('game/end', controller.end);
+gameRouter.get('/:id/commands', cmdController.get);
+gameRouter.post('/:id/commands/attack' , cmdController.attack );
+gameRouter.post('/:id/commands/deployTroops', cmdController.deployTroops);
+gameRouter.post('/:id/commands/endTurn', cmdController.endTurn);
 
 
 export default gameRouter

--- a/src/game/services/gameState.test.ts
+++ b/src/game/services/gameState.test.ts
@@ -1,7 +1,7 @@
 import db from  "../../db/db"
 import GameStateController from "./gameState"
 import { describe, it, expect, beforeAll } from '@jest/globals';
-import { Country } from "../../common/types";
+import { Country, CountryOwnershipRecord } from "../../common/types";
 
 
 
@@ -41,5 +41,16 @@ describe('GameService Integration Tests', () => {
       const gameID = "anyIDWillWork"
       const data: Country[] = await GameStateController(db).getCountries(gameID);
       expect(data.length).toEqual(42);
+    })
+
+    it('should update countries data and ownership data', async() => {
+      const gameID = "42"
+      let countries: Country[] = await GameStateController(db).getCountries(gameID);
+      countries[0].ownerID = "42";
+
+      await GameStateController(db).updateCountryOwnership(gameID, countries);
+
+      countries = await GameStateController(db).getCountries(gameID);
+      expect(countries[0].ownerID).toEqual("42");
     })
   });

--- a/src/game/services/gameState.ts
+++ b/src/game/services/gameState.ts
@@ -162,7 +162,7 @@ function GameStateController(db: Knex.Knex<any, unknown[]>) {
                         armies: row.armies,
                         created_at: row.created_at,
                         updated_at: row.updated_at,
-                        ownerId: row.ownerId
+                        ownerID: row.ownerId
                     }
                 })
             })
@@ -173,16 +173,16 @@ function GameStateController(db: Knex.Knex<any, unknown[]>) {
         for (let i = 1; i <= countries.length; i++) {
             let countryUpdate: CountryOwnershipRecord = {
                 countryId: countries[i-1].id.toString(),
-                ownerId: countries[i-1].ownerID,
+                ownerID: countries[i-1].ownerID,
             }
             // countryUpdate.gameID = gameID;
-            if (countryUpdate.ownerId !== undefined) {
+            if (countryUpdate.ownerID !== undefined) {
                 try {
                     let dbfun = await db("ownership")
                         // .from(`${OWNERSHIP_TABLE} as o`)
                         .where({countryId:countryUpdate.countryId})
                         .update({
-                            ownerId: countryUpdate.ownerId,
+                            ownerId: countryUpdate.ownerID,
                         // gameID: gameID,
                     })
                 } catch (err: any) {


### PR DESCRIPTION
Eliminated the dependency on a second command router. 

Now all command requests are made using the game/gameID/ route

Additionally, the gameID is no longer passed in as a body param, instead it's passed as a route parameter.

e.g. 
{{base_URL}}:{{PORT}}/game/new
{{base_URL}}:{{PORT}}/game/OsVsxVlsz4/commands/deployTroops
